### PR TITLE
モンスター名を日本語化

### DIFF
--- a/src/app/types/api_response.ts
+++ b/src/app/types/api_response.ts
@@ -24,3 +24,13 @@ export type Pokemon_Detail_API_Response = {
         back_default: string,
     },
 };
+
+export type Pokemon_Species_API_Response = {
+    names: {
+        name: string,
+        language: {
+            name: string,
+            url: string,
+        },
+    }[],
+};

--- a/src/app/types/api_response.ts
+++ b/src/app/types/api_response.ts
@@ -15,6 +15,10 @@ export type Pokemon_Detail_API_Response = {
     name: string,
     height: number,
     weight: number,
+    species: {
+        name: string,
+        url: string,
+    },
     sprites: {
         front_default: string,
         back_default: string,

--- a/src/app/utils/poke-api.ts
+++ b/src/app/utils/poke-api.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { Pokemons_API_Response, Pokemon_Detail_API_Response } from "../types/api_response";
+import { Pokemons_API_Response, Pokemon_Detail_API_Response, Pokemon_Species_API_Response } from "../types/api_response";
 
 export const getPokemonsData = async (page: number) => {
     const url = `https://pokeapi.co/api/v2/pokemon/?offset=${page * 20}&limit=20`;
@@ -10,7 +10,13 @@ export const getPokemonsData = async (page: number) => {
 
 export const getPokemonDetailData = async (url: string) => {
     const response = await axios.get<Pokemon_Detail_API_Response>(url);
+    response.data.name = await getPokemonJapaneseName(response.data.species.url);
     return response.data;
+}
+
+export const getPokemonJapaneseName = async (url: string) => {
+    const response = await axios.get<Pokemon_Species_API_Response>(url);
+    return response.data.names.find(name => name.language.name === "ja")!.name;
 }
 
 export const getPreviousPage = (page: number) => {


### PR DESCRIPTION
#4 の対応
---

これまで英語表記だったモンスター名を、日本語に変更。

`Pokemon Species Endpoint` から日本語名を取得して、
`Pokemon Endpoint` の名前を上書きした。
