### PR TITLE
ポケモンデータ表示用のカードコンポーネントの作成

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
+        pathname: "/PokeAPI/sprites/master/sprites/pokemon/**"
+      },
+    ],
+  }
+}
 
 module.exports = nextConfig

--- a/src/app/[page]/page.tsx
+++ b/src/app/[page]/page.tsx
@@ -1,7 +1,6 @@
-import { Suspense } from "react";
-
 import PagingButton from "../components/PagingButton";
-import { getPokemonsData, getPokemonDetailData, getPreviousPage, getNextPage } from "@/app/utils/poke-api";
+import MonsterCard from "../components/MonsterCard";
+import { getPokemonsData, getPreviousPage, getNextPage } from "@/app/utils/poke-api";
 
 type Params = {
     params: {
@@ -12,18 +11,16 @@ type Params = {
 
 export default async function Page( { params }: Params) {
     const currentPage = parseInt(params.page);
-    const pageData = await getPokemonsData(currentPage);
-    const { results } = pageData;
-    const detailList = await Promise.all(results.map(result => getPokemonDetailData(result.url)));
+    const { results } = await getPokemonsData(currentPage);
 
     return (
       <main>
         <h1>Pokemon</h1>
-        <Suspense fallback={<p>Loading...</p>}>
-          {detailList.map((d) => {
-            return (<div key={d.id}>{d.id}: {d.name}</div>)
-          })}
-        </Suspense>
+        <ul className="grid grid-cols-5 gap-4 max-w-4xl mx-auto mb-12">
+            {results.map(result => {
+              return <MonsterCard key={result.name} url={result.url} />
+            })}
+          </ul>
         <div className="flex gap-4 w-52 mx-auto mb-12">
           <PagingButton page={getPreviousPage(currentPage)}>previous</PagingButton>
           <PagingButton page={getNextPage(currentPage)}>next</PagingButton>

--- a/src/app/components/MonsterCard.tsx
+++ b/src/app/components/MonsterCard.tsx
@@ -1,0 +1,44 @@
+import Image from "next/image";
+
+import { getPokemonDetailData } from "@/app/utils/poke-api";
+import { Suspense } from "react";
+
+type Props = {
+  url: string,
+};
+
+const AsyncMonsterCard = async (props: Props) => {
+  const { name, height, weight, sprites } = await getPokemonDetailData(props.url);
+
+  return (
+    <>
+      <Image src={sprites.other["official-artwork"].front_default} alt={name} width={165} height={165} priority className="h-[165px] aspect-square my-2" />
+      <h2 className="font-bold text-center mb-3 py-2 bg-black text-white">{name}</h2>
+      <p className="px-2 mb-2">身長: {height}m</p>
+      <p className="px-2 mb-2">体重: {weight}kg</p>
+    </>
+  );
+};
+
+const SkeltonCard = () => {
+  return (
+    <>
+      <div className="h-[165px] aspect-square my-2"></div>
+      <h2 className="font-bold text-center mb-3 py-2 bg-black text-white">Loading...</h2>
+      <p className="px-2 mb-2">身長: -- m</p>
+      <p className="px-2 mb-2">体重: -- kg</p>
+    </>
+  )
+}
+
+const MonsterCard = (props: Props) => {
+  return (
+    <li className="bg-gray-200 text-black rounded h-[298px]">
+      <Suspense fallback={<SkeltonCard />}>
+        <AsyncMonsterCard url={props.url} />
+      </Suspense>
+    </li>
+  );
+};
+
+export default MonsterCard;

--- a/src/app/types/api_response.ts
+++ b/src/app/types/api_response.ts
@@ -22,6 +22,11 @@ export type Pokemon_Detail_API_Response = {
     sprites: {
         front_default: string,
         back_default: string,
+        other: {
+            "official-artwork": {
+                front_default: string,
+            },
+        },
     },
 };
 

--- a/src/app/utils/poke-api.ts
+++ b/src/app/utils/poke-api.ts
@@ -11,6 +11,8 @@ export const getPokemonsData = async (page: number) => {
 export const getPokemonDetailData = async (url: string) => {
     const response = await axios.get<Pokemon_Detail_API_Response>(url);
     response.data.name = await getPokemonJapaneseName(response.data.species.url);
+    response.data.height /= 10; //decimetres to metres
+    response.data.weight /= 10; //hectograms to kilograms
     return response.data;
 }
 


### PR DESCRIPTION
現在、仮表示しているポケモンのIDと名前部分を、
新しく作成したカードコンポーネントに差し替え。

## 表示内容
- オフィシャルアート画像
- 名前
- 身長(m)
- 体重(kg)