### PR TITLE
タイルレイアウト

### DIFF
--- a/src/app/[page]/page.module.css
+++ b/src/app/[page]/page.module.css
@@ -1,0 +1,6 @@
+.cardContainer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 10px;
+  margin-bottom: 30px;
+}

--- a/src/app/[page]/page.tsx
+++ b/src/app/[page]/page.tsx
@@ -1,6 +1,7 @@
 import PagingButton from "@/app/components/PagingButton";
 import MonsterCard from "@/app/components/MonsterCard";
 import { getPokemonsData, getPreviousPage, getNextPage } from "@/app/utils/poke-api";
+import styles from "./page.module.css"
 
 type Params = {
     params: {
@@ -14,7 +15,7 @@ export default async function Page( { params }: Params) {
 
     return (
         <>
-            <ul className="grid grid-cols-4 gap-4 mb-12">
+            <ul className={styles.cardContainer}>
                 {results.map(result => {
                     return <MonsterCard key={result.name} url={result.url} />
                 })}

--- a/src/app/components/MonsterCard.tsx
+++ b/src/app/components/MonsterCard.tsx
@@ -23,7 +23,6 @@ const AsyncMonsterCard = async (props: Props) => {
           width={165}
           height={165}
           priority
-          className="h-[165px] w-[165px]"
         /> :
         <Image
           src="/monster404.png"
@@ -31,7 +30,6 @@ const AsyncMonsterCard = async (props: Props) => {
           width={165}
           height={165}
           priority
-          className="h-[165px] w-[165px]"
         />
       }
       </div>

--- a/src/app/components/MonsterCard.tsx
+++ b/src/app/components/MonsterCard.tsx
@@ -97,7 +97,7 @@ const SkeltonCard = () => {
 
 const MonsterCard = (props: Props) => {
   return (
-    <li className="bg-gray-100 text-black text-sm rounded-lg h-[380px] drop-shadow-md overflow-hidden">
+    <li className="bg-gray-100 text-black text-sm rounded-lg drop-shadow-md overflow-hidden">
       <Suspense fallback={<SkeltonCard />}>
         <AsyncMonsterCard url={props.url} />
       </Suspense>


### PR DESCRIPTION
カードの幅を可変にして、ウィンドサイズに応じてカードのカラム数が変更される様にした。
その際、 `grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));` をtailwindcssで対応するのは難しそうだった為、新たにpage.module.cssを作成して、こちらで対応した。

また可変に応じて高さも変わる為、固定の高さ指定を削除した。