### PR TITLE
auto-fillにしてレイアウト崩れに対応

### DIFF
--- a/src/app/[page]/page.module.css
+++ b/src/app/[page]/page.module.css
@@ -1,6 +1,6 @@
 .cardContainer {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
   gap: 10px;
   margin-bottom: 30px;
 }


### PR DESCRIPTION
#15 の対応

最終ページのカードが1枚だけで、幅一杯に広がっていたのを、
適正幅になる様に修正。


`auto-fit` から `auto-fill` に変更。
|修正前|修正後|
|:--|:--|
|grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));|  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));|
