### PR TITLE
画像の優先指定を修正

### DIFF
--- a/src/app/[page]/page.tsx
+++ b/src/app/[page]/page.tsx
@@ -19,8 +19,8 @@ export default async function Page( { params }: Params) {
     return (
         <>
             <ul className={styles.cardContainer}>
-                {results.map(result => {
-                    return <MonsterCard key={result.url} url={result.url} />
+                {results.map((result, index) => {
+                    return <MonsterCard key={result.url} index={index} url={result.url} />
                 })}
             </ul>
             <div className="flex gap-4 w-52 mx-auto mb-12">

--- a/src/app/components/MonsterCard.tsx
+++ b/src/app/components/MonsterCard.tsx
@@ -8,6 +8,7 @@ import MonsterDataLabel from "@/app/components/MonsterDataLabel";
 
 type Props = {
   url: string,
+  index: number,
 };
 
 const AsyncMonsterCard = async (props: Props) => {
@@ -22,14 +23,14 @@ const AsyncMonsterCard = async (props: Props) => {
           alt={name}
           width={165}
           height={165}
-          priority
+          priority={props.index <= 11}
         /> :
         <Image
           src="/monster404.png"
           alt="Not Found"
           width={165}
           height={165}
-          priority
+          priority={props.index <= 11}
         />
       }
       </div>
@@ -60,11 +61,11 @@ const AsyncMonsterCard = async (props: Props) => {
   );
 };
 
-const SkeltonCard = () => {
+const SkeltonCard = (props: Props) => {
   return (
     <>
       <div className="h-[171px] w-full mb-4 bg-gradient-to-b from-gray-200 to-gray-400 flex justify-center items-center">
-        <Image src="/monster_ball.svg" alt="モンスターボール" width={70} height={70} priority className="animate-bounce" />
+        <Image src="/monster_ball.svg" alt="モンスターボール" width={70} height={70} priority={props.index <= 11} className="animate-bounce" />
       </div>
       <div className="p-3">
         <h2 className="font-bold mb-3">[No.--] Loading...</h2>
@@ -96,8 +97,8 @@ const SkeltonCard = () => {
 const MonsterCard = (props: Props) => {
   return (
     <li className="bg-gray-100 text-black text-sm rounded-lg drop-shadow-md overflow-hidden">
-      <Suspense fallback={<SkeltonCard />}>
-        <AsyncMonsterCard url={props.url} />
+      <Suspense fallback={<SkeltonCard {...props} />}>
+        <AsyncMonsterCard {...props} />
       </Suspense>
     </li>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
       <body className={inter.className}>
         <header className="bg-gradient-to-r from-gray-700 to-gray-500 mb-12">
           <h1 className="container mx-auto py-3">
-            <Image width="852" height="124" alt="Pokemon Book" src="/logo.png" className='w-[350px]' />
+            <Image width="852" height="124" alt="Pokemon Book" src="/logo.png" priority className='w-[350px]' />
           </h1>
         </header>
         <main className="container mx-auto">{children}</main>


### PR DESCRIPTION
モンスター一覧画面でモンスター画像の優先を、現在20件中20件を優先していた。
なので、ファーストビューに入る12件を優先する様に変更。

また必ずファーストビューに入るロゴ画像にも優先指定を追加。